### PR TITLE
Bioconductor review 1

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -33,11 +33,11 @@ on:
   push:
     branches:
       - master
-      ## - 'RELEASE_*'
+      - 'RELEASE_*'
   pull_request:
     branches:
       - master
-      ## - 'RELEASE_*'
+      - 'RELEASE_*'
 
 name: R-CMD-check-bioc
 
@@ -316,7 +316,8 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
-      BIOCVERSIONNUM: ${{ needs.R-CMD-check-bioc.outputs.biocversionnum }}
+      ## BIOCVERSIONNUM: ${{ needs.R-CMD-check-bioc.outputs.biocversionnum }}
+      BIOCVERSIONNUM: ${{ needs.define-docker-info.outputs.biocversion }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scp
 Title: Mass Spectrometry-Based Single-Cell Proteomics Data Analysis
-Version: 0.99.2
+Version: 0.99.3
 Authors@R:
     c(person("Christophe", "Vanderaa",
 	      email = "christophe.vanderaa@uclouvain.be",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,6 @@ Suggests:
     uwot
 License: Artistic-2.0
 Encoding: UTF-8
-LazyData: true
 VignetteBuilder: knitr
 biocViews: 
     GeneExpression,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,26 @@
 # scp 0.99
 
+## scp 0.99.3
+
+(nothing yet)
+
 ## scp 0.99.2
 
+- fix: solved 'invalid subsetting' issue
+  <2020-10-14 Wed>
+- Adapted the vignette to remove warnings and fix missing PCA plot.
+  <2020-10-14 Wed>
+- `README.md`: extended the installation guide, providing both a 
+  stable and a devel installation. 
+  <2020-10-13 Tue>
+- Removed the `LazyLoad` from the `DESCRIPTION` file and adapted the 
+  data loading (eg `data(scp1)` to `data("scp1")`)
+  <2020-10-13 Tue>
+- Documentation: added data collection description for the 3 example 
+  datasets
+  <2020-10-13 Tue>
 - fix: `computeFDR` can handle missing values (see issue #12)
+  <2020-10-02 Fri>
 
 ## scp 0.99.1
 

--- a/R/data.R
+++ b/R/data.R
@@ -146,6 +146,8 @@
 ##' - participated: a logical vector
 ##' - peptide: a character vector
 ##'
+##' @usage data("mqScpData")
+##' 
 ##' @details 
 ##' 
 ##' The dataset is a subset of the SCoPE2 dataset (version 2, Specht 
@@ -176,6 +178,8 @@
 ##' - sortday: a character vector
 ##' - digest: a character vector
 ##'
+##' @usage data("sampleAnnotation")
+##' 
 ##' @details 
 ##' 
 ##' ##' The dataset is a subset of the SCoPE2 dataset (version 2, Specht 
@@ -204,6 +208,8 @@
 ##' composed of 5 assays, including 3 PSM-level assays, 1 peptide
 ##' assay and 1 protein assay.
 ##' 
+##' @usage data("scp1")
+##' 
 ##' @details 
 ##' 
 ##' The dataset is a subset of the SCoPE2 dataset (version 2, Specht 
@@ -217,8 +223,10 @@
 ##' Then peptides were aggregated to proteins. 
 ##' 
 ##' @md
+##' 
+##' @docType data
 ##'
 ##' @examples
-##' data(scp1)
+##' data("scp1")
 ##' scp1
 "scp1"

--- a/R/data.R
+++ b/R/data.R
@@ -146,6 +146,18 @@
 ##' - participated: a logical vector
 ##' - peptide: a character vector
 ##'
+##' @details 
+##' 
+##' The dataset is a subset of the SCoPE2 dataset (version 2, Specht 
+##' et al. 2019, 
+##' [BioRXiv](https://www.biorxiv.org/content/10.1101/665307v3)). The 
+##' input file `evidence_unfiltered.csv` was downloaded from a 
+##' [Google Drive repository](https://drive.google.com/drive/folders/1VzBfmNxziRYqayx3SP-cOe2gu129Obgx).
+##' The MaxQuant evidence file was loaded and the data was cleaned 
+##' (renaming columns, removing duplicate fields,...).  MS runs that 
+##' were selected in the `scp1` dataset (see `?scp1`) were kept along 
+##' with a blank run. The data is stored as a `data.frame`.
+##' 
 ##' @seealso [readSCP()] for an example on how `mqScpData` is 
 ##'     parsed into a [QFeatures] object.
 ##' 
@@ -164,6 +176,21 @@
 ##' - sortday: a character vector
 ##' - digest: a character vector
 ##'
+##' @details 
+##' 
+##' ##' The dataset is a subset of the SCoPE2 dataset (version 2, Specht 
+##' et al. 2019, 
+##' [BioRXiv](https://www.biorxiv.org/content/10.1101/665307v3)). The 
+##' input files `batch.csv` and `annotation.csv` were downloaded from a 
+##' [Google Drive repository](https://drive.google.com/drive/folders/1VzBfmNxziRYqayx3SP-cOe2gu129Obgx).
+##' The two files were loaded and the columns names were adapted for 
+##' consistency with `mqScpData` table (see `?mqScpData`). The two 
+##' tables were filtered to contain only sets present in ``mqScpData`.
+##' The tables were then merged based on the run ID, hence merging the
+##' sample annotation and the batch annotation. Finally, annotation 
+##' for the blank run was added manually. The data is stored as a 
+##' `data.frame`.
+##' 
 ##' @seealso [readSCP()] to see how this file is used.
 ##'
 ##' @md
@@ -176,7 +203,19 @@
 ##' A small [QFeatures] object with SCoPE2 data. The object is
 ##' composed of 5 assays, including 3 PSM-level assays, 1 peptide
 ##' assay and 1 protein assay.
-##'
+##' 
+##' @details 
+##' 
+##' The dataset is a subset of the SCoPE2 dataset (version 2, Specht 
+##' et al. 2019, 
+##' [BioRXiv](https://www.biorxiv.org/content/10.1101/665307v3)).
+##' This dataset was converted to a [`QFeatures`] object where each 
+##' assay in stored as a [`SingleCellExperiment`] object. One assay 
+##' per chromatographic batch ("LCA9", "LCA10", "LCB3") was randomly
+##' sampled. For each assay, 100 proteins were randomly sampled. PSMs
+##' were then aggregated to peptides and joined in a single assay. 
+##' Then peptides were aggregated to proteins. 
+##' 
 ##' @md
 ##'
 ##' @examples

--- a/R/readSCP.R
+++ b/R/readSCP.R
@@ -176,7 +176,7 @@ readSCP <- function(quantTable,
 ##'
 ##' @examples 
 ##' ## Load a data.frame with PSM-level data
-##' data(mqScpData)
+##' data("mqScpData")
 ##' 
 ##' ## Create the QFeatures object
 ##' sce <- readSingleCellExperiment(mqScpData, 

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,7 +34,7 @@ rowDataToDF <- function(obj,
     if (!inherits(obj, "QFeatures")) stop("'obj' must be a QFeatures object")
     if (is.numeric(i)) i <- names(obj)[i]
     ## Make sure that the variables to extract are present in the rowData
-    mis <- vapply(experiments(obj)[i], 
+    mis <- vapply(experiments(obj)[, , i], 
                   function(x) any(!vars %in% colnames(rowData(x))),
                   logical(1))
     if (any(mis)) 
@@ -137,7 +137,7 @@ aggregateFeaturesOverAssays <- function(obj,
     if (is.numeric(i)) i <- names(obj)[i]
     
     ## Compute the aggregated assays
-    el <- obj@ExperimentList[i]
+    el <- experiments(obj)[, , i]
     for (j in seq_along(el)) {
         suppressMessages(
             el[[j]] <- aggregateFeatures(el[[j]], 
@@ -146,9 +146,7 @@ aggregateFeaturesOverAssays <- function(obj,
                                          ...)
         )
         ## Print progress
-        message(paste0("\rAggregated: ", j, "/", length(el)))
-        if (j == length(el)) cat ("\n")
-        flush.console()
+        message("\rAggregated: ", j, "/", length(el), "\n")
     }
     names(el) <- name
     ## Get the AssayLinks for the aggregated assays 

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,7 +34,7 @@ rowDataToDF <- function(obj,
     if (!inherits(obj, "QFeatures")) stop("'obj' must be a QFeatures object")
     if (is.numeric(i)) i <- names(obj)[i]
     ## Make sure that the variables to extract are present in the rowData
-    mis <- vapply(experiments(obj)[, , i], 
+    mis <- vapply(experiments(obj)[i], 
                   function(x) any(!vars %in% colnames(rowData(x))),
                   logical(1))
     if (any(mis)) 
@@ -137,7 +137,7 @@ aggregateFeaturesOverAssays <- function(obj,
     if (is.numeric(i)) i <- names(obj)[i]
     
     ## Compute the aggregated assays
-    el <- experiments(obj)[, , i]
+    el <- experiments(obj)[i]
     for (j in seq_along(el)) {
         suppressMessages(
             el[[j]] <- aggregateFeatures(el[[j]], 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,17 @@ objects.
 
 ## Installation
 
+To install the stable version:
+
 ```
 if (!requireNamespace("BiocManager"))
 	install.packages("BiocManager")
+BiocManager::install("UCLouvain-CBIO/scp")
+```
+
+To install the development version:
+
+```
 BiocManager::install("UCLouvain-CBIO/scp")
 ```
 

--- a/man/computeFDR.Rd
+++ b/man/computeFDR.Rd
@@ -9,8 +9,8 @@ computeFDR(object, i, groupCol, pepCol)
 \arguments{
 \item{object}{A \code{QFeatures} object}
 
-\item{i}{A \code{numeric()} or \code{character()} vector indicating from which
-assays the \code{rowData} should be taken.}
+\item{i}{A \code{numeric()} or \code{character()} vector indicating from
+which assays the \code{rowData} should be taken.}
 
 \item{groupCol}{A \code{character(1)} indicating the variable names in the
 \code{rowData} that contains the grouping variable. The FDR are usually
@@ -24,9 +24,9 @@ variable must be contained in (0, 1).}
 A \code{QFeatures} object.
 }
 \description{
-The functions takes the posterior error probabilities (PEPs) from the given
-assay's \code{rowData} and creates a new variable (\code{.FDR}) to it that
-contains the computed false discovery rates (FDRs).
+The functions takes the posterior error probabilities (PEPs) from
+the given assay's \code{rowData} and adds a new variable to it (called
+\code{.FDR}) that contains the computed false discovery rates (FDRs).
 }
 \examples{
 data("scp1")

--- a/man/computeMedianCV.Rd
+++ b/man/computeMedianCV.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/compute_metrics.R
 \name{computeMedianCV}
 \alias{computeMedianCV}
-\title{Compute cell median coefficient of variation (CV)}
+\title{Compute the median coefficient of variation (CV) per cell}
 \usage{
 computeMedianCV(object, i, peptideCol, proteinCol, batchCol)
 }

--- a/man/mqScpData.Rd
+++ b/man/mqScpData.Rd
@@ -8,7 +8,7 @@
 An object of class \code{data.frame} with 1197 rows and 139 columns.
 }
 \usage{
-mqScpData
+data("mqScpData")
 }
 \description{
 A \code{data.frame} with 1088 observations and 139 variables, as
@@ -155,6 +155,17 @@ produced by reading a MaxQuant output file with
 \item participated: a logical vector
 \item peptide: a character vector
 }
+}
+\details{
+The dataset is a subset of the SCoPE2 dataset (version 2, Specht
+et al. 2019,
+\href{https://www.biorxiv.org/content/10.1101/665307v3}{BioRXiv}). The
+input file \code{evidence_unfiltered.csv} was downloaded from a
+\href{https://drive.google.com/drive/folders/1VzBfmNxziRYqayx3SP-cOe2gu129Obgx}{Google Drive repository}.
+The MaxQuant evidence file was loaded and the data was cleaned
+(renaming columns, removing duplicate fields,...).  MS runs that
+were selected in the \code{scp1} dataset (see \code{?scp1}) were kept along
+with a blank run. The data is stored as a \code{data.frame}.
 }
 \seealso{
 \code{\link[=readSCP]{readSCP()}} for an example on how \code{mqScpData} is

--- a/man/readSingleCellExperiment.Rd
+++ b/man/readSingleCellExperiment.Rd
@@ -43,7 +43,7 @@ are forbidden in the \code{rowData}. Avoid using the following names:
 }
 \examples{
 ## Load a data.frame with PSM-level data
-data(mqScpData)
+data("mqScpData")
 
 ## Create the QFeatures object
 sce <- readSingleCellExperiment(mqScpData, 

--- a/man/sampleAnnotation.Rd
+++ b/man/sampleAnnotation.Rd
@@ -8,7 +8,7 @@
 An object of class \code{data.frame} with 64 rows and 6 columns.
 }
 \usage{
-sampleAnnotation
+data("sampleAnnotation")
 }
 \description{
 A data frame with 48 observations on the following 6 variables.
@@ -20,6 +20,16 @@ A data frame with 48 observations on the following 6 variables.
 \item sortday: a character vector
 \item digest: a character vector
 }
+}
+\details{
+##' The dataset is a subset of the SCoPE2 dataset (version 2, Specht
+et al. 2019,
+\href{https://www.biorxiv.org/content/10.1101/665307v3}{BioRXiv}). The
+input files \code{batch.csv} and \code{annotation.csv} were downloaded from a
+\href{https://drive.google.com/drive/folders/1VzBfmNxziRYqayx3SP-cOe2gu129Obgx}{Google Drive repository}.
+The two files were loaded and the columns names were adapted for
+consistency with \code{mqScpData} table (see \code{?mqScpData}). The two
+tables were filtered to contain only sets present in ``mqScpData\verb{. The tables were then merged based on the run ID, hence merging the sample annotation and the batch annotation. Finally, annotation  for the blank run was added manually. The data is stored as a  }data.frame`.
 }
 \seealso{
 \code{\link[=readSCP]{readSCP()}} to see how this file is used.

--- a/man/scp1.Rd
+++ b/man/scp1.Rd
@@ -8,15 +8,26 @@
 An object of class \code{QFeatures} of length 5.
 }
 \usage{
-scp1
+data("scp1")
 }
 \description{
 A small \link{QFeatures} object with SCoPE2 data. The object is
 composed of 5 assays, including 3 PSM-level assays, 1 peptide
 assay and 1 protein assay.
 }
+\details{
+The dataset is a subset of the SCoPE2 dataset (version 2, Specht
+et al. 2019,
+\href{https://www.biorxiv.org/content/10.1101/665307v3}{BioRXiv}).
+This dataset was converted to a \code{\link{QFeatures}} object where each
+assay in stored as a \code{\link{SingleCellExperiment}} object. One assay
+per chromatographic batch ("LCA9", "LCA10", "LCB3") was randomly
+sampled. For each assay, 100 proteins were randomly sampled. PSMs
+were then aggregated to peptides and joined in a single assay.
+Then peptides were aggregated to proteins.
+}
 \examples{
-data(scp1)
+data("scp1")
 scp1
 }
 \keyword{datasets}

--- a/vignettes/scp.Rmd
+++ b/vignettes/scp.Rmd
@@ -11,8 +11,8 @@ output:
     toc_depth: 2
     code_folding: show
 bibliography: scp.bib
-date: "`r doc_date()`"
-package: "`r pkg_ver('scp')`"
+date: "`r BiocStyle::doc_date()`"
+package: "`r BiocStyle::pkg_ver('scp')`"
 vignette: >
   %\VignetteIndexEntry{Single Cell Proteomics data processing and analysis}
   %\VignetteEngine{knitr::rmarkdown}
@@ -858,7 +858,8 @@ plot, here we called it `PCA`. The samples are colored by type of sample.
 ```{r plot_PCA}
 plotReducedDim(scp[["proteins_batchC"]],
                dimred = "PCA",
-               colour_by = "SampleType")
+               colour_by = "SampleType",
+               point_alpha = 1)
 ```
 
 This is a minimalistic example with only a few plotted cells, but the
@@ -892,7 +893,8 @@ colored by type of sample.
 ```{r plot_UMAP}
 plotReducedDim(scp[["proteins_batchC"]],
                dimred = "UMAP",
-               colour_by = "SampleType")
+               colour_by = "SampleType",
+               point_alpha = 1)
 ```
 
 The UMAP plot is a very interesting plot for large datasets. A UMAP on

--- a/vignettes/scp.Rmd
+++ b/vignettes/scp.Rmd
@@ -381,11 +381,11 @@ here use the median value. We name the aggregated assays using the
 original names and appending `peptides_` at the start.
 
 ```{r aggregate_peptides, message = FALSE}
-scp <-aggregateFeaturesOverAssays(scp,
-                                  i = 1:3,
-                                  fcol = "peptide",
-                                  name = paste0("peptides_", names(scp)),
-                                  fun = matrixStats::colMedians, na.rm = TRUE)
+scp <- aggregateFeaturesOverAssays(scp,
+                                   i = 1:3,
+                                   fcol = "peptide",
+                                   name = paste0("peptides_", names(scp)),
+                                   fun = matrixStats::colMedians, na.rm = TRUE)
 ```
 
 Notice that 3 new assays were created in the `scp` object. Those new
@@ -842,9 +842,9 @@ PCA can be computed using the `runPCA` method. It returns a
 `SingleCellExperiment` object for which the dimension reduction
 results are stored in the `reducedDim` slot.
 
-```{r run_PCA, warning = FALSE}
+```{r run_PCA}
 scp[["proteins_batchC"]] <- runPCA(scp[["proteins_batchC"]],
-                                   ncomponents = 50,
+                                   ncomponents = 5,
                                    ntop = Inf,
                                    scale = TRUE,
                                    exprs_values = 1,


### PR DESCRIPTION
I updated the package based on the [Bioconductor review](https://github.com/Bioconductor/Contributions/issues/1628). Here are the changes:

- `README.md`: extended the installation guide, providing both a stable and a devel installation.
- Removed the `LazyLoad` from the `DESCRIPTION` file and adapted the data loading (eg `data(scp1)` to `data("scp1")`)
- Documentation: added data collection description for the 3 example datasets
- Adapted the vignette to remove warnings and fix the PCA plot. However, I could not reproduce the missing plot. @lgatto, could you double-check that the PCA section seems correct (no warning and the PCA plot appears)?