### PR TITLE
Optimisation of aggregateFeaturesOverAssays

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,78 +1,97 @@
 
 ##' Aggregate features over multiple assays
-##' 
+##'
 ##' This function is a wrapper function around
-##' [QFeatures::aggregateFeatures]. 
-##' It allows the user to provide multiple assays for which 
+##' [QFeatures::aggregateFeatures].
+##' It allows the user to provide multiple assays for which
 ##' `aggregateFeatures` will be applied sequentially.
-##' 
+##'
 ##' @param object A `QFeatures` object
-##' 
+##'
 ##' @param i A `numeric(1)` or `character(1)` indicating which assay
 ##'     to transfer the `colData` to.
-##' 
+##'
 ##' @param fcol The feature variables for each assays `i` defining how
 ##'     to summarise the QFeatures. If `fcol` has length 1, the
 ##'     variable name is assumed to be the same for all assays
-##' 
+##'
 ##' @param name A `character()` naming the new assay. `name` must have
 ##'     the same length as `i`. Note that the function will fail if of
 ##'     the names in `name` is already present.
-##' 
+##'
 ##' @param fun A function used for quantitative feature aggregation.
-##' 
+##'
+##' @param uniformRowData A `logical()` that specify if the new assays should
+##'     have the same rowData invariant columns
+##'     (Note that turning uniformRowData to FALSE can have a negative impact
+##'     on perfomances)
+##'
 ##' @param ... Additional parameters passed the `fun`.
-##' 
-##' @return A `QFeatures` object 
-##' 
+##'
+##' @return A `QFeatures` object
+##'
 ##' @export
 ##'
 ##' @importFrom utils flush.console
 ##' @importFrom methods new
 ##' @importFrom S4Vectors metadata
 ##' @importFrom MultiAssayExperiment experiments
-##' 
+##'
 ##' @seealso [QFeatures::aggregateFeatures]
-##' 
-##' @examples 
+##'
+##' @examples
 ##' data("scp1")
-##' scp1 <- aggregateFeaturesOverAssays(scp1, 
+##' scp1 <- aggregateFeaturesOverAssays(scp1,
 ##'                                     i = 1:3,
 ##'                                     fcol = "peptide",
 ##'                                     name = paste0("peptides", 1:3),
 ##'                                     fun = colMeans,
 ##'                                     na.rm = TRUE)
 ##' scp1
-##' 
-aggregateFeaturesOverAssays <- function(object, i, fcol, name, fun, ...) {
+##'
+aggregateFeaturesOverAssays <- function(object,
+                                        i,
+                                        fcol,
+                                        name,
+                                        fun,
+                                        uniformRowData = TRUE,
+                                        ...) {
     if (length(i) != length(name)) stop("'i' and 'name' must have same length")
     if (length(fcol) == 1) fcol <- rep(fcol, length(i))
     if (length(i) != length(fcol)) stop("'i' and 'fcol' must have same length")
     if (is.numeric(i)) i <- names(object)[i]
-    
+
     ## Compute the aggregated assays
     el <- experiments(object)[i]
+    if (uniformRowData) rowDataColsKept <- colnames(rowData(el[[1]]))
     for (j in seq_along(el)) {
+        if (uniformRowData) rowData(el[[j]]) <- rowData(el[[j]])[, rowDataColsKept]
         suppressMessages(
-            el[[j]] <- aggregateFeatures(el[[j]], fcol = fcol[j], 
+            el[[j]] <- aggregateFeatures(el[[j]], fcol = fcol[j],
                                          fun = fun, ...)
         )
+        if (uniformRowData) rowDataColsKept <- intersect(rowDataColsKept, colnames(rowData(el[[j]])))
         ## Print progress
         message("\rAggregated: ", j, "/", length(el), "\n")
     }
+    if (uniformRowData) {
+        for (j in seq_along(el)) {
+        rowData(el[[j]]) <- rowData(el[[j]])[, rowDataColsKept]
+        }
+    }
     names(el) <- name
-    ## Get the AssayLinks for the aggregated assays 
+    ## Get the AssayLinks for the aggregated assays
     alnks <- lapply(seq_along(i), function(j) {
         hits <- QFeatures:::.get_Hits(rdFrom = rowData(object[[i[j]]]),
-                                      rdTo = rowData(el[[j]]), 
-                                      varFrom = fcol[[j]], 
+                                      rdTo = rowData(el[[j]]),
+                                      varFrom = fcol[[j]],
                                       varTo = fcol[[j]])
         AssayLink(name = name[j], from = i[j], fcol = fcol[j], hits = hits)
     })
     ## Append the aggregated assays and AssayLinks to the previous assays
     el <- c(object@ExperimentList, el)
     alnks <- append(object@assayLinks, AssayLinks(alnks))
-    ## Update the sampleMapfrom the data 
+    ## Update the sampleMapfrom the data
     smap <- MultiAssayExperiment:::.sampleMapFromData(colData(object), el)
     ## Create the new QFeatures object
     new("QFeatures",


### PR DESCRIPTION
Hello I hope you are doing well.
I recently conducted a lot of performance benchmarks on the QFeatures and scp packages, focusing on basic workflows. These benchmarks revealed that the `aggregateFeaturesOverAssays` function from scp is the most time-consuming step relative to the other steps in the workflow.

To understand the cause of this performance bottleneck, I profiled the `aggregateFeaturesOverAssays` function. The results indicated that the majority of the runtime is consumed by the `invariant_cols2` function call from the QFeatures package. This function verifies, for each assay and for each column in `rowData`, that the column has unique values within a specific column for a peptide.

After exploring the code, I did not find a direct way to optimize this check operation. However, I discovered an approach that significantly reduces computation time by using already computed results. Since the invariance check is performed for each assay, we can extract the selected invariant columns from the `rowData` of the previous assay and use this to subset the next assay. This selection of invariant columns is updated iteratively as we progress through the loop over the assays. At the end of the loop, we ensure that all assays have the same number of columns in `rowData`, as the earlier assays might initially have more columns than the later ones (note that this extra step does not significantly increase the overall runtime) .

However, this optimization modifies the function's output. Previously, the function checked the invariance of all columns for each assay independently. If a column was marked as invariant in one assay, it was retained, whereas if the same column was marked as variant in another assay, it was dropped. This resulted in different `rowData` dimensions across assays, leading to the generation of many NA values when joining the assays.

I do not believe that losing these columns with mixed invariant and variant behavior across assays is problematic. If a column is marked as variant in an assay, the data it contains should not be relevant at the peptide scale and can therefore be discarded in the peptide assays.

Here to accommodate both the old and new behaviors, I modified the function to include an additional parameter. This parameter allows to choose whether to enforce the old behavior or to apply the optimized approach. The performance improvement is significant, as shown in the figure bellow, where I compare the function with `uniformRowData` set to `FALSE` or `TRUE` with different input size (replicate = 3). The performance gain is more pronounced with an increasing number of assays.

![benchmarkAggregateFeaturesOverAssays](https://github.com/user-attachments/assets/39a469dd-f85c-41f7-a668-a9b8568faf73)


I would appreciate your thoughts on this:
1. Is the new behavior correct?
2. Does the performance gain is sufficient to justify a change like this?
3. If we implement this, should we use a parameter to allow users to choose between the new and old behavior?
4. What should be the default value for this parameter?

Additionally, if we decide to adopt the new implementation, I will need to update the test cases to account for specific situations where the results differ between the old and new implementations. Currently, the tests pass locally with the new implementation.

@lgatto @cvanderaa 