### PR TITLE
Fix grep pattern in example for readSingleCellExperiment

### DIFF
--- a/R/readSCP.R
+++ b/R/readSCP.R
@@ -51,7 +51,7 @@
 ##'
 ##' ## Create the QFeatures object
 ##' sce <- readSingleCellExperiment(mqScpData,
-##'                                 quantCols = grep("RI", colnames(mqScpData)))
+##'                                 quantCols = grep("Reporter.intensity.\\d", colnames(mqScpData)))
 ##' sce
 ##'
 ##' ######################################################


### PR DESCRIPTION
Hi,

I think the grep pattern in the current example for ``readSingleCellExperiment`` is not correct, as it returns no quant columns and therefore the SingleCellExperiment contains no data. I believe the pattern from your vignette is the correct one and fixes that.

Best,
Micha